### PR TITLE
Be compatible with current datalad core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,12 @@ install:
   - sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers
 
 script:
-  # Report WTF information using system wide installed version
-  - datalad wtf
   # Verify that setup.py build doesn't puke
   - python setup.py build
   # Test installation system-wide
   - sudo pip install .
+  # Report WTF information using system wide installed version
+  - datalad wtf
   # Run tests
   - http_proxy=
     PATH=$PWD/tools/coverage-bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 language: python
 
 python:
-  - 2.7
   - 3.5
   - 3.6
 
@@ -16,7 +15,7 @@ env:
     - DATALAD_LOG_CMD_ENV=GIT_SSH_COMMAND
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
   matrix:
-    - DATALAD_REPO_VERSION=6
+    - DATALAD_REPO_VERSION=7
     - DATALAD_REPO_VERSION=5
 
 

--- a/datalad_webapp/resources/file.py
+++ b/datalad_webapp/resources/file.py
@@ -136,7 +136,7 @@ class FileResource(WebAppResource):
                 json_py.loads(args.content), file_abspath)
         else:
             open(file_abspath, 'w').write(args.content)
-        self.ds.add(
+        self.ds.save(
             file_abspath,
             to_git=args.togit,
             #message="",

--- a/datalad_webapp/tests/test_file.py
+++ b/datalad_webapp/tests/test_file.py
@@ -5,7 +5,7 @@ import os.path as op
 
 from datalad.api import (
     create,
-    add,
+    save,
     webapp,
 )
 
@@ -51,7 +51,7 @@ def test_read(client):
         file_content = '{"three": 3}'
         # resource picks up live changes to the dataset
         create_tree(ds.path, {'subdir': {'dummy': file_content}})
-        ds.add('.')
+        ds.save()
         current_files = c.get('/api/v1/file').get_json()['files']
         testpath = 'subdir/dummy'
         assert testpath not in existing_files
@@ -104,7 +104,7 @@ def test_delete(client):
         file_content = '{"three": 3}'
         # resource picks up live changes to the dataset
         create_tree(ds.path, {'subdir': {'dummy': file_content}})
-        ds.add('.')
+        ds.save()
         assert testpath in c.get('/api/v1/file').get_json()['files']
 
         rq = c.delete(

--- a/datalad_webapp/tests/test_procedure.py
+++ b/datalad_webapp/tests/test_procedure.py
@@ -14,7 +14,7 @@ def client(tmpdir):
     with open(os.path.join(ds.path, 'dummy_procedure.py'), 'w') as f:
         f.write("import sys; print(\"This is a dummy procedure running in %s\" "
                 "% sys.argv[1]")
-    ds.add('dummy_procedure.py', to_git=True, save=False)
+    ds.save('dummy_procedure.py', to_git=True, message="dummy procedure added")
 
     ds.config.add(
         'datalad.locations.dataset-procedures',
@@ -30,7 +30,7 @@ def client(tmpdir):
         "This is a help message",
         where='dataset'
     )
-    ds.save(message="dummy procedure added")
+    ds.save(message="dummy procedure config added")
 
     res = webapp(
         dataset=ds.path,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # If you want to develop, use requirements-devel.txt
-git+https://github.com/datalad/datalad.git
+#git+https://github.com/datalad/datalad.git
+

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=[pkg for pkg in find_packages('.') if pkg.startswith('datalad')],
     # datalad command suite specs from here
     install_requires=[
-        'datalad',
+        'datalad>=0.12',
         'Flask>=1.0',
         'Flask-RESTful',
         'pytest-cov',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=[pkg for pkg in find_packages('.') if pkg.startswith('datalad')],
     # datalad command suite specs from here
     install_requires=[
-        'datalad>=0.12',
+        'datalad>=0.12.5',
         'Flask>=1.0',
         'Flask-RESTful',
         'pytest-cov',


### PR DESCRIPTION
- [x] remove deprecated uses of `datalad-add`
- [x] depend on datalad 0.12.5
- [x] remove PY2 test builds
- [x] test against released datalad instead of its master branch